### PR TITLE
Start building TAStm32 under CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
+fbsd_task:
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  env:
+    PATH: /usr/local/gcc-arm-embedded/bin:${PATH}
+  install_script:
+    - pkg install -y gcc-arm-embedded gmake
+  build_script:
+    - gmake
+
+linux_task:
+  container:
+    image: gcc:latest
+  install_script:
+    - apt-get update
+    - apt-get install -y binutils-arm-none-eabi gcc-arm-none-eabi libnewlib-arm-none-eabi
+  build_script:
+    - make

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ C_INCLUDES =  \
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
 CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
-CFLAGS += -Werror -std=c99
+CFLAGS += -Werror -std=c11
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2


### PR DESCRIPTION
Now that the project has a Makefile, setup CI using Cirrus CI to test-build with GCC on both FreeBSD and Linux, the former being included mostly for testing environment diversity.

You can sign up at https://cirrus-ci.com/ and give them some access to the repository (it's not too invasive, IIRC) in order to see the results.

The build's also been switched to C11 in order to more closely match what's done via TrueSTUDIO.