### PR TITLE
Sauraen's Initial GameCube/N64 Changes

### DIFF
--- a/Inc/TASRun.h
+++ b/Inc/TASRun.h
@@ -1,11 +1,9 @@
 #ifndef __TASRUN__H
 #define __TASRUN__H
 
-#include <stdint.h>
+#include "main.h"
 #include "n64.h"
 #include "snes.h"
-#include "stm32f4xx_hal.h"
-#include "main.h"
 
 #define MAX_SIZE 1024
 #define MAX_CONTROLLERS 2
@@ -72,7 +70,6 @@ extern TASRun tasruns[MAX_NUM_RUNS];
 // This file includes a load of static functions with definitions to make
 // inlining easier
 
-#define maybe_unused  __attribute__((unused))
 
 maybe_unused static TASRun *TASRunGetByIndex(uint8_t runNum)
 {
@@ -138,25 +135,6 @@ maybe_unused static Console TASRunGetConsole(const TASRun *tasrun)
 maybe_unused static uint8_t GetSizeOfInputForRun(const TASRun *tasrun)
 {
 	return tasrun->input_data_size;
-}
-
-maybe_unused static void SetN64InputMode()
-{
-	// port C4 to input mode
-	const uint32_t MODER_SLOT = (P1_DATA_2_Pin*P1_DATA_2_Pin);
-	const uint32_t MODER_MASK = 0b11 * MODER_SLOT;
-	const uint32_t MODER_NEW_VALUE = GPIO_MODE_INPUT * MODER_SLOT;
-
-	P1_DATA_2_GPIO_Port->MODER = (P1_DATA_2_GPIO_Port->MODER & ~MODER_MASK) | MODER_NEW_VALUE;
-}
-
-maybe_unused static void SetN64OutputMode()
-{
-	// port C4 to output mode
-	const uint32_t MODER_SLOT = (P1_DATA_2_Pin*P1_DATA_2_Pin);
-	const uint32_t MODER_MASK = 0b11 * MODER_SLOT;
-	const uint32_t MODER_NEW_VALUE = GPIO_MODE_OUTPUT_PP * MODER_SLOT;
-	P1_DATA_2_GPIO_Port->MODER = (P1_DATA_2_GPIO_Port->MODER & ~MODER_MASK) | MODER_NEW_VALUE;
 }
 
 // Functions below here are complex enough to not try to inline

--- a/Inc/main.h
+++ b/Inc/main.h
@@ -53,6 +53,8 @@ extern "C" {
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 
+#include <stdint.h>
+
 /* USER CODE END Includes */
 
 /* Exported types ------------------------------------------------------------*/
@@ -68,6 +70,8 @@ extern volatile uint8_t jumpToDFU;
 /* Exported macro ------------------------------------------------------------*/
 /* USER CODE BEGIN EM */
 
+#define maybe_unused  __attribute__((unused))
+
 /* USER CODE END EM */
 
 /* Exported functions prototypes ---------------------------------------------*/
@@ -76,6 +80,8 @@ void Error_Handler(void);
 /* USER CODE BEGIN EFP */
 void ReInitClockTimers(void);
 void JumpToBootLoader(void);
+
+void my_wait_us_asm(int n);
 /* USER CODE END EFP */
 
 /* Private defines -----------------------------------------------------------*/

--- a/Inc/n64.h
+++ b/Inc/n64.h
@@ -1,7 +1,7 @@
 #ifndef __N64__H
 #define __N64__H
 
-#include <stdint.h>
+#include "main.h"
 
 typedef struct __attribute__((packed))
 {
@@ -56,14 +56,63 @@ typedef struct __attribute__((packed))
 
 } GCControllerData; // all bits are in the correct order... except for the analog
 
-void initialize_n64_buffer();
-uint32_t readCommand();
-void SendIdentityN64();
-void SendIdentityGC();
-void SendOriginGC();
-void SendRunDataN64(N64ControllerData data);
-void SendControllerDataN64(unsigned long data);
-void SendRunDataGC(GCControllerData gcdata);
-void SendControllerDataGC(uint64_t data);
+
+maybe_unused static void GCN64_SetPortInput()
+{
+	// port C4 to input mode
+	const uint32_t MODER_SLOT = (P1_DATA_2_Pin*P1_DATA_2_Pin);
+	const uint32_t MODER_MASK = 0b11 * MODER_SLOT;
+	const uint32_t MODER_NEW_VALUE = GPIO_MODE_INPUT * MODER_SLOT;
+
+	P1_DATA_2_GPIO_Port->MODER = (P1_DATA_2_GPIO_Port->MODER & ~MODER_MASK) | MODER_NEW_VALUE;
+}
+
+maybe_unused static void GCN64_SetPortOutput()
+{
+	// port C4 to output mode
+	const uint32_t MODER_SLOT = (P1_DATA_2_Pin*P1_DATA_2_Pin);
+	const uint32_t MODER_MASK = 0b11 * MODER_SLOT;
+	const uint32_t MODER_NEW_VALUE = GPIO_MODE_OUTPUT_PP * MODER_SLOT;
+	P1_DATA_2_GPIO_Port->MODER = (P1_DATA_2_GPIO_Port->MODER & ~MODER_MASK) | MODER_NEW_VALUE;
+}
+
+maybe_unused static void GCN64_Send0()
+{
+	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin<<16;
+	my_wait_us_asm(3);
+	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin;
+	my_wait_us_asm(1);
+}
+maybe_unused static void GCN64_Send1()
+{
+	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin<<16;
+	my_wait_us_asm(1);
+	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin;
+	my_wait_us_asm(3);
+}
+maybe_unused static void GCN64_SendStop()
+{
+	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin<<16;
+	my_wait_us_asm(1);
+	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin;
+}
+maybe_unused static void GCN64_SendData(uint8_t *data, uint8_t bytes)
+{
+	while(bytes){
+		uint8_t d = *data;
+		for(uint8_t b=0; b<8; ++b){
+			(d & 0x80) ? GCN64_Send1() : GCN64_Send0();
+			d <<= 1;
+		}
+		++data;
+		--bytes;
+	}
+	GCN64_SendStop();
+}
+
+uint32_t GCN64_ReadCommand();
+void N64_SendIdentity();
+void GCN_SendIdentity();
+void GCN_SendOrigin();
 
 #endif

--- a/Src/n64.c
+++ b/Src/n64.c
@@ -4,15 +4,43 @@
 #include "stm32f4xx_hal.h"
 #include "main.h"
 
-void my_wait_us_asm(int n);
-
-static uint8_t GetMiddleOfPulse();
-static void SendByte(unsigned char b);
-
 // N64 data pin is p1_d2
 #define N64_READ (P1_DATA_2_GPIO_Port->IDR & P1_DATA_2_Pin)
 
-uint32_t readCommand()
+static uint8_t GetMiddleOfPulse()
+{
+	uint8_t ct = 0;
+    // wait for line to go high
+    while(1)
+    {
+        if(N64_READ) break;
+
+        ct++;
+        if(ct == 200) // failsafe limit TBD
+        	return 5; // error code
+    }
+
+    ct = 0;
+
+    // wait for line to go low
+    while(1)
+    {
+        if(!N64_READ) break;
+
+        ct++;
+		if(ct == 200) // failsafe limit TBD
+			return 5; // error code
+    }
+
+    // now we have the falling edge
+
+    // wait 2 microseconds to be in the middle of the pulse, and read. high --> 1.  low --> 0.
+    my_wait_us_asm(2);
+
+    return N64_READ ? 1U : 0U;
+}
+
+uint32_t GCN64_ReadCommand()
 {
 	uint8_t retVal;
 
@@ -49,225 +77,31 @@ uint32_t readCommand()
     }
 }
 
-static uint8_t GetMiddleOfPulse()
-{
-	uint8_t ct = 0;
-    // wait for line to go high
-    while(1)
-    {
-        if(N64_READ) break;
-
-        ct++;
-        if(ct == 200) // failsafe limit TBD
-        	return 5; // error code
-    }
-
-    ct = 0;
-
-    // wait for line to go low
-    while(1)
-    {
-        if(!N64_READ) break;
-
-        ct++;
-		if(ct == 200) // failsafe limit TBD
-			return 5; // error code
-    }
-
-    // now we have the falling edge
-
-    // wait 2 microseconds to be in the middle of the pulse, and read. high --> 1.  low --> 0.
-    my_wait_us_asm(2);
-
-    return N64_READ ? 1U : 0U;
-}
-
-void SendStop()
-{
-	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin<<16;
-	my_wait_us_asm(1);
-	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin;
-}
-
-void SendIdentityN64()
+void N64_SendIdentity()
 {
     // reply 0x05, 0x00, 0x02
-    SendByte(0x05);
-    SendByte(0x00);
-    SendByte(0x02);
-    SendStop();
+	uint32_t data = 0x00020005;
+	GCN64_SendData((uint8_t*)&data, 3);
 }
 
-void write_1()
+void GCN_SendIdentity()
 {
-	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin<<16;
-	my_wait_us_asm(1);
-	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin;
-    my_wait_us_asm(3);
+	// reply 0x90, 0x00, 0x0C
+	uint32_t data = 0x000C0090;
+	GCN64_SendData((uint8_t*)&data, 3);
 }
 
-void write_0()
+void GCN_SendOrigin()
 {
-	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin<<16;
-	my_wait_us_asm(3);
-	P1_DATA_2_GPIO_Port->BSRR = P1_DATA_2_Pin;
-    my_wait_us_asm(1);
-}
+	uint8_t buf[10];
+	memset(buf, 0, sizeof(buf));
+	GCControllerData *gc_data = (GCControllerData*)&buf[0];
 
-// send a byte from LSB to MSB (proper serialization)
-static void SendByte(unsigned char b)
-{
-    for(int i = 0;i < 8;i++) // send all 8 bits, one at a time
-    {
-        if((b >> i) & 1)
-        {
-            write_1();
-        }
-        else
-        {
-            write_0();
-        }
-    }
-}
+	gc_data->a_x_axis = 128;
+	gc_data->a_y_axis = 128;
+	gc_data->c_x_axis = 128;
+	gc_data->c_y_axis = 128;
+	gc_data->beginning_one = 1;
 
-void SendRunDataN64(N64ControllerData n64data)
-{
-	unsigned long data = 0;
-	memcpy(&data,&n64data,sizeof(data));
-    // send one byte at a time from MSB to LSB
-	unsigned int size = sizeof(data); // should be 4 bytes
-
-    for(unsigned int i = 0;i < size;i++) // for each byte
-    {
-    	for(int b = 7;b >=0;b--) // for each bit in the byte
-    	{
-			if((data >> (b+(i*8)) & 1))
-			{
-				write_1();
-			}
-			else
-			{
-				write_0();
-			}
-    	}
-    }
-
-    SendStop();
-}
-
-void SendControllerDataN64(unsigned long data)
-{
-    // send one byte at a time from MSB to LSB
-	unsigned int size = sizeof(data); // should be 4 bytes
-
-    for(unsigned int i = 0;i < size;i++) // for each byte
-    {
-    	for(int b = 7;b >=0;b--) // for each bit in the byte
-    	{
-			if((data >> (b+(i*8)) & 1))
-			{
-				write_1();
-			}
-			else
-			{
-				write_0();
-			}
-    	}
-    }
-
-    SendStop();
-}
-
-void SendRunDataGC(GCControllerData gcdata)
-{
-	uint64_t data = 0;
-	memcpy(&data,&gcdata,sizeof(data));
-
-    unsigned int size = sizeof(data); // should be 8 bytes
-
-    for(unsigned int i = 0;i < size;i++) // for each byte
-	{
-		for(int b = 7;b >=0;b--) // for each bit in the byte
-		{
-			if((data >> (b+(i*8)) & 1))
-			{
-				write_1();
-			}
-			else
-			{
-				write_0();
-			}
-		}
-	}
-
-    SendStop();
-}
-
-void SendControllerDataGC(uint64_t data)
-{
-    unsigned int size = sizeof(data); // should be 8 bytes
-
-    for(unsigned int i = 0;i < size;i++) // for each byte
-	{
-		for(int b = 7;b >=0;b--) // for each bit in the byte
-		{
-			if((data >> (b+(i*8)) & 1))
-			{
-				write_1();
-			}
-			else
-			{
-				write_0();
-			}
-		}
-	}
-
-    SendStop();
-}
-
-void SendIdentityGC()
-{
-    SendByte(0x90);
-    SendByte(0x00);
-    SendByte(0x0C);
-    SendStop();
-}
-
-void SendOriginGC()
-{
-	GCControllerData gc_data;
-
-	memset(&gc_data, 0, sizeof(gc_data));
-
-	gc_data.a_x_axis = 128;
-	gc_data.a_y_axis = 128;
-	gc_data.c_x_axis = 128;
-	gc_data.c_y_axis = 128;
-	gc_data.beginning_one = 1;
-	gc_data.l_trigger = 0;
-	gc_data.r_trigger = 0;
-
-	uint64_t data = 0;
-	memcpy(&data,&gc_data,sizeof(data));
-
-	unsigned int size = sizeof(data); // should be 8 bytes
-
-	for(unsigned int i = 0;i < size;i++) // for each byte
-	{
-		for(int b = 7;b >=0;b--) // for each bit in the byte
-		{
-			if((data >> (b+(i*8)) & 1))
-			{
-				write_1();
-			}
-			else
-			{
-				write_0();
-			}
-		}
-	}
-
-	SendByte(0x00);
-	SendByte(0x00);
-	SendStop();
+	GCN64_SendData(buf, sizeof(buf));
 }


### PR DESCRIPTION
I've went through the work of rebasing @Sauraen's initial GameCube/N64 changes:
https://github.com/sauraen/TAStm32/commit/a25a085c30bffd24e2fc15000ad4c7d7f2b78d6f

To the top of the current master as of writing this pull request. 
https://github.com/Ownasaurus/TAStm32/commit/5b1c5d7a89d6b2974644b1489d456196d209cf09

This does not add Multiplayer support for N64/GC, I made this PR initially to fix the missing controller issue with certain N64 games, but I can work on rebasing those changes as well, just let me know.

These changes has fixed an persistent issue where certain games will not recognize the controller being plugged in and will just display an error message instead (large image of Ocarina of Time):
https://cdn.discordapp.com/attachments/549117504317030401/752349834140450906/20200906_190844_HDR.jpg

I've tested the following N64 games, noting the ones that had the same issue like the above:

| Game | Has Controller Issue | Controller Issue Fixed | Syncs |
| --- | --- | --- | --- |
| Mortal Kombat 4 | :heavy_check_mark:  | :heavy_check_mark:  | :heavy_check_mark:  |
| Ocarina of Time (JP 1.0) | :heavy_check_mark:  | :heavy_check_mark:  | :x: |
| Super Mario 64 (JP and US) | :x: | :heavy_check_mark:  | :heavy_check_mark: |

One last edit: I did not use any blank frames for any of these.  MK4 desyncs if you add any blank frames, so don't add any!

This is the commit as presented right now.  I am willing to make any changes as needed, such as cleaning up some spots (but will need to make sure it still works)