### PR TITLE
GC/N64: Fix controller bit ordering with SendByte

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Serisium (@serisium) - helped with debugging and PCB design
 
 rcombs (@rcombs) - helped with optimizing the N64 protocol
 
-Sauraen (@sauraen) - Linux setup and installation notes
+Sauraen (@sauraen) - Linux setup and installation notes, along with additional work on the GC/N64 protocol.
+
+sspx (@SuperSpyTX) - For help with finding a bug in the N64 controller identity code.
 
 #### If I accidentally forgot to credit you, please let me know so I can fix it!
 

--- a/Src/n64.c
+++ b/Src/n64.c
@@ -117,7 +117,7 @@ void write_0()
 // send a byte from LSB to MSB (proper serialization)
 static void SendByte(unsigned char b)
 {
-    for(int i = 0;i < 8;i++) // send all 8 bits, one at a time
+    for(int i = 7;i >= 0;i--) // send all 8 bits, one at a time
     {
         if((b >> i) & 1)
         {

--- a/Src/n64.c
+++ b/Src/n64.c
@@ -227,9 +227,9 @@ void SendControllerDataGC(uint64_t data)
 
 void SendIdentityGC()
 {
-    SendByte(0x90);
+    SendByte(0x09);
     SendByte(0x00);
-    SendByte(0x0C);
+    SendByte(0x30);
     SendStop();
 }
 


### PR DESCRIPTION
So it turns out after some random code chunk testing, it seems that by changing the order in which the controller bits were sent in the SendByte function, certain games as mentioned in #32 now recognize the controller being plugged into it, as previously they were not being recognized.

**No addtional tests** besides Mortal Kombat 4 have been made, I am currently sharing a TV and thus screen time is short.  I am going to do more tests later this evening, but I highly recommend testing.

**Update** All the games I tested in the last Pull Request #32 works with this commit! :smile: (besides SM64 JP, because I assume it'd work too) 

I am also going to recommend that you compile this because my TrueSTUDIO firmware is still giving me issues about "Buffer Overflow x1" despite it being windows compiled :|