### PR TITLE
Style change request from Ownasaurus: use capital letters in hex constants for consistency

### DIFF
--- a/Src/serial_interface.c
+++ b/Src/serial_interface.c
@@ -41,7 +41,7 @@ void serial_interface_consume(uint8_t *buffer, uint32_t n)
 			case SERIAL_PREFIX:
 				switch(input)
 				{
-					case '\xaa': // ping
+					case '\xAA': // ping
 						serial_interface_output((uint8_t*)"\x55", 1); // pong
 						break;
 					case 'U': // set up latch train for a run


### PR DESCRIPTION
Title.