### PR TITLE
cirrus: drop CIRRUS_CLONE_DEPTH limitation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,3 @@
-env:
-  CIRRUS_CLONE_DEPTH: 1
-
 fbsd_task:
   freebsd_instance:
     image: freebsd-12-1-release-amd64


### PR DESCRIPTION
The default is a sane value for any projects, and it's also well-suited
here. Drop it to let Cirrus do the right thing if multiple commits get
pushed.