### PR TITLE
cirrus: fix fbsd build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 fbsd_task:
   freebsd_instance:
-    image: freebsd-12-1-release-amd64
+    image: freebsd-12-2-release-amd64
   env:
     PATH: /usr/local/gcc-arm-embedded/bin:${PATH}
   install_script:
-    - pkg install -y gcc-arm-embedded gmake
+    - pkg install -y gcc-arm-embedded gmake git
   build_script:
     - gmake
 


### PR DESCRIPTION
FreeBSD 12.1 has gone EoL and the image organization for FreeBSD is a
little suboptimal for CI. Bump it to 12.2 for now, hopefully there can be
a generic "FreeBSD-12" type family in the future.

While we're here, start installing git to silence some noise.