### PR TITLE
"wait for next rumble" transition / melee poll alarm bug mitigation

### DIFF
--- a/Inc/TASRun.h
+++ b/Inc/TASRun.h
@@ -38,7 +38,8 @@ typedef enum
 	TRANSITION_NORMAL,
 	TRANSITION_ACE,
 	TRANSITION_RESET_SOFT,
-	TRANSITION_RESET_HARD
+	TRANSITION_RESET_HARD,
+	TRANSITION_WAIT_RUMBLE
 } TransitionType;
 
 typedef struct
@@ -69,6 +70,7 @@ typedef struct
 	uint8_t input_data_size;
 	uint32_t moder_firstLatch;
 
+	uint8_t waiting; // if we're waiting on a rumble
 	uint8_t multitap;
 	int32_t blank;
 	char inputFile[256];

--- a/Inc/TASRun.h
+++ b/Inc/TASRun.h
@@ -71,7 +71,6 @@ typedef struct
 	uint32_t moder_firstLatch;
 	uint8_t meleeMitigation;
 	uint32_t pollNumber;
-	uint32_t skipped;
 	uint8_t waiting; // if we're waiting on a rumble
 	uint8_t multitap;
 	int32_t blank;

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ $(BUILD_DIR):
 #######################################
 flash:
 	-./python/tastm32-dfu.py
-	sleep 5
+	sleep 3
 	dfu-util -a 0 -s 0x08000000:leave -D $(BUILD_DIR)/$(TARGET).bin
 
 #######################################

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_exti.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash_ex.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pwr_ex.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd.c \
-Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c \
+Src/system_stm32f4xx.c \
 Src/yaml/parser.c \
 Src/yaml/dumper.c \
 Src/yaml/loader.c \

--- a/Src/TASRun.c
+++ b/Src/TASRun.c
@@ -90,6 +90,9 @@ uint8_t TASRunIncrementFrameCount()
 			case TRANSITION_RESET_HARD:
 				return 3;
 				break;
+			case TRANSITION_WAIT_RUMBLE:
+				return 4;
+				break;
 			}
 		}
 

--- a/Src/serial_interface.c
+++ b/Src/serial_interface.c
@@ -449,6 +449,16 @@ void serial_interface_consume(uint8_t *buffer, uint32_t n)
 						break;
 					}
 				}
+				else if(instance.transition_type == 'R')
+				{
+					if(!AddTransition(TRANSITION_WAIT_RUMBLE, tempVal)) // try adding transition
+					{
+						// adding transition failed
+						instance.state = SERIAL_COMPLETE;
+						serial_interface_output((uint8_t*)"\xFB", 1);
+						break;
+					}
+				}
 
 				instance.state = SERIAL_COMPLETE;
 				break;

--- a/Src/stm32f4xx_it.c
+++ b/Src/stm32f4xx_it.c
@@ -961,8 +961,9 @@ void GCN64_CommandStart(uint8_t player)
 	  case 0x400300:
 	  case 0x400301:
 
-		tasrun->pollNumber++;
-		
+		if(player == tasrun->numControllers)
+			tasrun->pollNumber++;
+
 		// stop waiting if we recieved a rumble
 		// (LSB of command indicates rumble state)
 		if (tasrun->waiting && (cmd & 1))

--- a/Src/stm32f4xx_it.c
+++ b/Src/stm32f4xx_it.c
@@ -969,6 +969,7 @@ void GCN64_CommandStart(uint8_t player)
 			tasrun->pollNumber = 1;
 		}
 
+		// start waiting if the previous iteration told us to
 		if (toggleNext == 4)
 		{
 			tasrun->waiting = 1;
@@ -983,7 +984,7 @@ void GCN64_CommandStart(uint8_t player)
 		else if(player == tasrun->numControllers)
 		{
 			frame = GetNextFrame();
-				tasrun->pollNumber++;
+			tasrun->pollNumber++;
 
 			// Skip one out of every thousand frames to work around Melee polling bug
 			if (tasrun->meleeMitigation && tasrun->pollNumber % 1000 == 1){

--- a/Src/stm32f4xx_it.c
+++ b/Src/stm32f4xx_it.c
@@ -959,6 +959,13 @@ void GCN64_CommandStart(uint8_t player)
 	  case 0x400300:
 	  case 0x400301:
 
+		if (toggleNext == 4)
+		{
+			tasrun->waiting = 1;
+			//GPIOB->BSRR = (1 << V1_D0_LOW_B);
+			toggleNext = 0;
+		}
+
 		// stop waiting if we recieved a rumble
 		// (LSB of command indicates rumble state)
 		if (tasrun->waiting && (cmd & 1))
@@ -976,7 +983,7 @@ void GCN64_CommandStart(uint8_t player)
 			frame = GetNextFrame();
 		}
 
-		if(frame == NULL) // buffer underflow
+		if(frame == NULL) // buffer underflow or waiting
 		{
 			memset(&gc_data, 0, sizeof(gc_data));
 
@@ -990,6 +997,7 @@ void GCN64_CommandStart(uint8_t player)
 		}
 		else
 		{
+			toggleNext = TASRunIncrementFrameCount();
 			frame[0][(player-1)][0].gc_data.beginning_one = 1;
 			GC_SendRunData(player, frame[0][(player-1)][0].gc_data);
 		}

--- a/Src/stm32f4xx_it.c
+++ b/Src/stm32f4xx_it.c
@@ -914,6 +914,7 @@ void GCN64_CommandStart(uint8_t player)
 	__disable_irq();
 	uint32_t cmd;
 	static RunDataArray *frame = NULL;
+	uint8_t bufferUnderflow = 0;
 
 	cmd = GCN64_ReadCommand(player);
 
@@ -945,6 +946,7 @@ void GCN64_CommandStart(uint8_t player)
 
 		  if(frame == NULL) // buffer underflow
 		  {
+			  bufferUnderflow = 1;
 			  N64_SendControllerData(player, 0); // send blank controller data
 		  }
 		  else
@@ -981,6 +983,8 @@ void GCN64_CommandStart(uint8_t player)
 		else if(player == tasrun->numControllers)
 		{
 			frame = GetNextFrame();
+			if (frame == NULL)
+			    bufferUnderflow = 1;
 		}
 
 		if(frame == NULL) // buffer underflow or waiting
@@ -1035,7 +1039,7 @@ void GCN64_CommandStart(uint8_t player)
 				}
 				else
 				{
-					if(frame == NULL) // there was a buffer underflow
+					if(bufferUnderflow) // there was a buffer underflow
 						serial_interface_output((uint8_t*)"A\xB2", 2);
 					else
 						serial_interface_output((uint8_t*)"A", 1);

--- a/Src/stm32f4xx_it.c
+++ b/Src/stm32f4xx_it.c
@@ -961,6 +961,8 @@ void GCN64_CommandStart(uint8_t player)
 	  case 0x400300:
 	  case 0x400301:
 
+		tasrun->pollNumber++;
+		
 		// stop waiting if we recieved a rumble
 		// (LSB of command indicates rumble state)
 		if (tasrun->waiting && (cmd & 1))
@@ -984,7 +986,7 @@ void GCN64_CommandStart(uint8_t player)
 		else if(player == tasrun->numControllers)
 		{
 			frame = GetNextFrame();
-			tasrun->pollNumber++;
+			
 
 			// Skip one out of every thousand frames to work around Melee polling bug
 			if (tasrun->meleeMitigation && tasrun->pollNumber % 1000 == 1){

--- a/Src/stm32f4xx_it.c
+++ b/Src/stm32f4xx_it.c
@@ -988,7 +988,6 @@ void GCN64_CommandStart(uint8_t player)
 
 			// Skip one out of every thousand frames to work around Melee polling bug
 			if (tasrun->meleeMitigation && tasrun->pollNumber % 1000 == 1){
-				tasrun->skipped++;
 				GetNextFrame();
 			}
 			if (frame == NULL)

--- a/Src/usbplayback/menu.c
+++ b/Src/usbplayback/menu.c
@@ -88,7 +88,7 @@ void Menu_Display() {
 	static FILINFO fno;
 
 	unsigned char lineNo = 0;
-	CurrentMenu = MENUTYPE_TASSTATS;
+
 	switch (CurrentMenu) {
 	case MENUTYPE_BROWSER:
 
@@ -263,14 +263,6 @@ void Menu_Display() {
 
 		sprintf(temp, "Buffer: %d", tasrun->size);
 		ssd1306_SetCursor(0, 16);
-		ssd1306_WriteString(temp, Font_6x8, White);
-
-		sprintf(temp, "Skipped: %d", tasrun->skipped);
-		ssd1306_SetCursor(0, 24);
-		ssd1306_WriteString(temp, Font_6x8, White);
-
-		sprintf(temp, "pollnumber: %d", tasrun->pollNumber);
-		ssd1306_SetCursor(0, 32);
 		ssd1306_WriteString(temp, Font_6x8, White);
 
 		ssd1306_UpdateScreen();

--- a/Src/usbplayback/menu.c
+++ b/Src/usbplayback/menu.c
@@ -88,13 +88,13 @@ void Menu_Display() {
 	static FILINFO fno;
 
 	unsigned char lineNo = 0;
-
+	CurrentMenu = MENUTYPE_TASSTATS;
 	switch (CurrentMenu) {
 	case MENUTYPE_BROWSER:
 
 		// if USB host initiated run, switch menu
 		if (tasrun->initialized){
-			CurrentMenu = MENUTYPE_TASINPUTS;
+			CurrentMenu = MENUTYPE_TASSTATS;
 			break;
 		}
 
@@ -264,6 +264,11 @@ void Menu_Display() {
 		sprintf(temp, "Buffer: %d", tasrun->size);
 		ssd1306_SetCursor(0, 16);
 		ssd1306_WriteString(temp, Font_6x8, White);
+
+		sprintf(temp, "Waiting: %d", tasrun->waiting);
+		ssd1306_SetCursor(0, 24);
+		ssd1306_WriteString(temp, Font_6x8, White);
+
 
 		ssd1306_UpdateScreen();
 		break;

--- a/Src/usbplayback/menu.c
+++ b/Src/usbplayback/menu.c
@@ -88,13 +88,13 @@ void Menu_Display() {
 	static FILINFO fno;
 
 	unsigned char lineNo = 0;
-	CurrentMenu = MENUTYPE_TASSTATS;
+
 	switch (CurrentMenu) {
 	case MENUTYPE_BROWSER:
 
 		// if USB host initiated run, switch menu
 		if (tasrun->initialized){
-			CurrentMenu = MENUTYPE_TASSTATS;
+			CurrentMenu = MENUTYPE_TASINPUTS;
 			break;
 		}
 
@@ -264,11 +264,6 @@ void Menu_Display() {
 		sprintf(temp, "Buffer: %d", tasrun->size);
 		ssd1306_SetCursor(0, 16);
 		ssd1306_WriteString(temp, Font_6x8, White);
-
-		sprintf(temp, "Waiting: %d", tasrun->waiting);
-		ssd1306_SetCursor(0, 24);
-		ssd1306_WriteString(temp, Font_6x8, White);
-
 
 		ssd1306_UpdateScreen();
 		break;

--- a/python/pokefloats.sh
+++ b/python/pokefloats.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-./tastm32.py --console gc --transition 5085 R --hardreset pokefloats_v10.dtm

--- a/python/tastm32.py
+++ b/python/tastm32.py
@@ -149,6 +149,9 @@ class TAStm32():
             elif mode == b'H':
                 # Set Hard Reset
                 command = b''.join([b'T', prefix, mode, struct.pack('I', frame)])
+            elif mode == b'R':
+                # Wait for next rumble
+                command = b''.join([b'T', prefix, mode, struct.pack('I', frame)])
             if command != '':
                 self.write(command)
 
@@ -340,6 +343,8 @@ def main():
                 transition[1] = b'S'
             elif transition[1] == 'H':
                 transition[1] = b'H'
+            elif transition[1] == 'R':
+                transition[1] = b'R'
 
     if args.latchtrain != '':
         args.latchtrain = [int(x) for x in args.latchtrain.split(',')]


### PR DESCRIPTION
Pause inputs at the requested frame and resume when the next rumble signal is sent from the console.

This is primarily intended to allow Melee to sync, as it has non-deterministic (disc-based) load times.